### PR TITLE
Adds homepage and replace global color palette

### DIFF
--- a/apps/nextjs/public/Ellipse-3.svg
+++ b/apps/nextjs/public/Ellipse-3.svg
@@ -1,0 +1,9 @@
+<svg width="41" height="41" viewBox="0 0 41 41" fill="none" xmlns="http://www.w3.org/2000/svg">
+<circle cx="20.5" cy="20.5" r="20.5" fill="url(#paint0_linear_104_132)"/>
+<defs>
+<linearGradient id="paint0_linear_104_132" x1="20.5" y1="0" x2="20.5" y2="41" gradientUnits="userSpaceOnUse">
+<stop stop-color="#020817"/>
+<stop offset="1" stop-color="#2563EB" stop-opacity="0.47"/>
+</linearGradient>
+</defs>
+</svg>

--- a/apps/nextjs/src/app/dashboard/page.tsx
+++ b/apps/nextjs/src/app/dashboard/page.tsx
@@ -1,0 +1,3 @@
+export default function page() {
+  return <div>Dashboard</div>;
+}

--- a/apps/nextjs/src/app/globals.css
+++ b/apps/nextjs/src/app/globals.css
@@ -5,46 +5,46 @@
 @layer base {
   :root {
     --background: 0 0% 100%;
-    --foreground: 240 10% 3.9%;
+    --foreground: 222.2 84% 4.9%;
     --card: 0 0% 100%;
-    --card-foreground: 240 10% 3.9%;
+    --card-foreground: 222.2 84% 4.9%;
     --popover: 0 0% 100%;
-    --popover-foreground: 240 10% 3.9%;
-    --primary: 327 66% 69%;
-    --primary-foreground: 337 65.5% 17.1%;
-    --secondary: 240 4.8% 95.9%;
-    --secondary-foreground: 240 5.9% 10%;
-    --muted: 240 4.8% 95.9%;
-    --muted-foreground: 240 3.8% 46.1%;
-    --accent: 240 4.8% 95.9%;
-    --accent-foreground: 240 5.9% 10%;
-    --destructive: 0 72.22% 50.59%;
-    --destructive-foreground: 0 0% 98%;
-    --border: 240 5.9% 90%;
-    --input: 240 5.9% 90%;
-    --ring: 240 5% 64.9%;
+    --popover-foreground: 222.2 84% 4.9%;
+    --primary: 222.2 84% 4.9%;
+    --primary-foreground: 210 40% 98%;
+    --secondary: 210 40% 96.1%;
+    --secondary-foreground: 222.2 47.4% 11.2%;
+    --muted: 210 40% 96.1%;
+    --muted-foreground: 215.4 16.3% 46.9%;
+    --accent: 210 40% 96.1%;
+    --accent-foreground: 222.2 47.4% 11.2%;
+    --destructive: 0 84.2% 60.2%;
+    --destructive-foreground: 210 40% 98%;
+    --border: 214.3 31.8% 91.4%;
+    --input: 214.3 31.8% 91.4%;
+    --ring: 221.2 83.2% 53.3%;
     --radius: 0.5rem;
   }
 
   .dark {
-    --background: 240 10% 3.9%;
-    --foreground: 0 0% 98%;
-    --card: 240 10% 3.9%;
-    --card-foreground: 0 0% 98%;
-    --popover: 240 10% 3.9%;
-    --popover-foreground: 0 0% 98%;
-    --primary: 327 66% 69%;
-    --primary-foreground: 337 65.5% 17.1%;
-    --secondary: 240 3.7% 15.9%;
-    --secondary-foreground: 0 0% 98%;
-    --muted: 240 3.7% 15.9%;
-    --muted-foreground: 240 5% 64.9%;
-    --accent: 240 3.7% 15.9%;
-    --accent-foreground: 0 0% 98%;
+    --background: 222.2 84% 4.9%;
+    --foreground: 210 40% 98%;
+    --card: 222.2 84% 4.9%;
+    --card-foreground: 210 40% 98%;
+    --popover: 222.2 84% 4.9%;
+    --popover-foreground: 210 40% 98%;
+    --primary: 217.2 91.2% 59.8%;
+    --primary-foreground: 222.2 47.4% 11.2%;
+    --secondary: 217.2 32.6% 17.5%;
+    --secondary-foreground: 210 40% 98%;
+    --muted: 217.2 32.6% 17.5%;
+    --muted-foreground: 215 20.2% 65.1%;
+    --accent: 217.2 32.6% 17.5%;
+    --accent-foreground: 210 40% 98%;
     --destructive: 0 62.8% 30.6%;
-    --destructive-foreground: 0 85.7% 97.3%;
-    --border: 240 3.7% 15.9%;
-    --input: 240 3.7% 15.9%;
-    --ring: 240 4.9% 83.9%;
+    --destructive-foreground: 210 40% 98%;
+    --border: 217.2 32.6% 17.5%;
+    --input: 217.2 32.6% 17.5%;
+    --ring: 224.3 76.3% 48%;
   }
 }

--- a/apps/nextjs/src/app/page.tsx
+++ b/apps/nextjs/src/app/page.tsx
@@ -1,13 +1,36 @@
-import { HelloClient } from "./_components/hello-client";
-import { HelloServer } from "./_components/hello-server";
+import Image from "next/image";
+import Link from "next/link";
+
+import { Button } from "@feprep/ui/button";
+
+import "@feprep/ui";
 
 export const runtime = "edge";
 
 export default async function HomePage() {
   return (
-    <main>
-      <HelloClient />
-      <HelloServer />
-    </main>
+    <div className="flex flex-1 flex-col items-start justify-center">
+      <div className="ml-12">
+        <Image
+          src="/Ellipse-3.svg"
+          width={50}
+          height={50}
+          alt="Picture of the author"
+          className="mb-8"
+        />
+        <h1 className="mb-4  text-left text-6xl font-semibold">FEPrep</h1>
+        <h2 className="mb-4  max-w-sm text-left text-3xl font-normal leading-normal">
+          A new way to prepare for the Foundation Exam.
+        </h2>
+        <div className="flex flex-row gap-5">
+          <Button type="submit">
+            <Link href="/dashboard">Start Practicing</Link>
+          </Button>
+          <Button type="submit" className="bg-slate-500">
+            <Link href="/sign-up">Create Account</Link>
+          </Button>
+        </div>
+      </div>
+    </div>
   );
 }


### PR DESCRIPTION
- Imports SVG for gradient logo
- Creates homepage with title and buttons to redirect to /dashboard and /sign-up
- Add empty dashboard page for redirect
- Replaces global colors from shadcn theming


