### PR TITLE
Apply Android workaround

### DIFF
--- a/apps/expo/index.ts
+++ b/apps/expo/index.ts
@@ -1,0 +1,1 @@
+import "expo-router/entry";

--- a/apps/expo/package.json
+++ b/apps/expo/package.json
@@ -2,7 +2,7 @@
   "name": "@feprep/expo",
   "version": "0.0.0",
   "private": true,
-  "main": "expo-router/entry",
+  "main": "index.ts",
   "scripts": {
     "clean": "git clean -xdf .expo .turbo node_modules",
     "dev": "expo start",


### PR DESCRIPTION
Currently, we aren't able to test the mobile app on an Android device. This workaround outlined here in [this GitHub issue](https://github.com/expo/expo/issues/26787) works wonders. This seems like an issue regarding Expo router which gives file-based routing.