### PR TITLE
Remove statement breakpoints in migration scripts

### DIFF
--- a/packages/db/migrations/0001_closed_energizer.sql
+++ b/packages/db/migrations/0001_closed_energizer.sql
@@ -5,7 +5,8 @@
                   https://stackoverflow.com/questions/2083543/modify-a-columns-type-in-sqlite3
 
  Due to that we don't generate migration automatically and it has to be done manually
-*/--> statement-breakpoint
+*/
+
 /*
  SQLite does not support "Changing existing column type" out of the box, we do not generate automatic migration for that, so it has to be done manually
  Please refer to: https://www.techonthenet.com/sqlite/tables/alter_table.php
@@ -13,5 +14,5 @@
                   https://stackoverflow.com/questions/2083543/modify-a-columns-type-in-sqlite3
 
  Due to that we don't generate migration automatically and it has to be done manually
-*/--> statement-breakpoint
+*/
 ALTER TABLE user ADD `email_verified` integer DEFAULT 0 NOT NULL;

--- a/packages/db/src/migrate.ts
+++ b/packages/db/src/migrate.ts
@@ -3,3 +3,5 @@ import { migrate } from "drizzle-orm/libsql/migrator";
 import { db } from ".";
 
 await migrate(db, { migrationsFolder: "./migrations" });
+
+console.log("Database migrated!");


### PR DESCRIPTION
See [this issue](https://github.com/drizzle-team/drizzle-orm/issues/1709)